### PR TITLE
+Pairwise

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2.108
+        dotnet-version: 6.0.403 
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Test with dotnet

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ obj/
 .ionide/
 .idea/
 .vscode/
+*.user

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Description>Collections and collection extensions</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <VersionPrefix>1.2.0</VersionPrefix>
-    <VersionSuffix>beta-2</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
     <PackageProjectUrl>https://github.com/wallymathieu/Collections</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/wallymathieu/Collections.git</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Description>Collections and collection extensions</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <VersionPrefix>1.2.0</VersionPrefix>
-    <VersionSuffix>beta-1</VersionSuffix>
+    <VersionSuffix>beta-2</VersionSuffix>
     <PackageProjectUrl>https://github.com/wallymathieu/Collections</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/wallymathieu/Collections.git</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,8 +3,8 @@
     <Authors>WallyMathieu;OzzyMcDuff</Authors>
     <Description>Collections and collection extensions</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <VersionPrefix>1.1.0</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionSuffix>beta-1</VersionSuffix>
     <PackageProjectUrl>https://github.com/wallymathieu/Collections</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/wallymathieu/Collections.git</RepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Yields the result of the application of the map function over each pair.
 ```c#
 using WallyMathieu.Collections;
 ...
-var pairs = Enumerable.Range(0,4).Pairwise(Tuple.Create).ToArray(); 
+var pairs = Enumerable.Range(0,4).Pairwise().ToArray(); 
 // will be
-Assert.Equal(new[] { Tuple.Create(0, 1), Tuple.Create(1, 2), Tuple.Create(2, 3) },pairs);
+Assert.Equal(new[] { (0, 1), (1, 2), (2, 3) },pairs);
 ```

--- a/README.md
+++ b/README.md
@@ -69,3 +69,16 @@ foreach (var batch in hugelist.BatchesOf(2000))
 }
 ...
 ```
+
+### Pairwise
+
+Used to iterate over collection and get the collection elements pairwise.
+Yields the result of the application of the map function over each pair.
+
+```c#
+using WallyMathieu.Collections;
+...
+var pairs = Enumerable.Range(0,4).Pairwise(Tuple.Create).ToArray(); 
+// will be
+Assert.Equal(new[] { Tuple.Create(0, 1), Tuple.Create(1, 2), Tuple.Create(2, 3) },pairs);
+```

--- a/Tests/PairwiseTests.cs
+++ b/Tests/PairwiseTests.cs
@@ -11,14 +11,14 @@ namespace Tests
         public void Pairwise()
         {
             var r = Enumerable.Range(0,5);
-            var result = r.Pairwise(Tuple.Create);
-            Assert.Equal(new[] { Tuple.Create(0, 1), Tuple.Create(1, 2), Tuple.Create(2, 3), Tuple.Create(3, 4) },
+            var result = r.Pairwise();
+            Assert.Equal(new[] { (0, 1), (1, 2), (2, 3), (3, 4) },
                 result.ToArray());
         }
         [Fact]
         public void Pairwise_tuple()
         {
-            var result = Enumerable.Range(0, 5).Pairwise((i, i1) => (i,i1)); //TODO: Add overload next API version
+            var result = Enumerable.Range(0, 5).Pairwise();
             Assert.Equal(new[] { (0, 1), (1, 2), (2, 3), (3, 4) },
                 result.ToArray());
         }
@@ -26,29 +26,29 @@ namespace Tests
         [Fact]
         public void Pairwise_for_list_of_odd_length()
         {
-            var result = Enumerable.Range(0, 4).Pairwise(Tuple.Create);
-            Assert.Equal(new[] { Tuple.Create(0, 1), Tuple.Create(1, 2), Tuple.Create(2, 3) },
+            var result = Enumerable.Range(0, 4).Pairwise();
+            Assert.Equal(new[] { (0, 1), (1, 2), (2, 3) },
                 result.ToArray());
         }
         [Fact]
         public void Pairwise_for_list_of_odd_length_tuple()
         {
-            var result = Enumerable.Range(0, 4).Pairwise((i, i1) => (i,i1)); //TODO: Add overload next API version
+            var result = Enumerable.Range(0, 4).Pairwise();
             Assert.Equal(new[] { (0, 1), (1, 2), (2, 3) },
                 result.ToArray());
         }
         [Fact]
         public void ShouldHandleEmptyCollection()
         {
-            var emptyList = new string[0];
-            var result = emptyList.Pairwise(Tuple.Create).ToList();
+            var emptyList = Array.Empty<string>();
+            var result = emptyList.Pairwise().ToList();
             Assert.Empty(result);
         }
         [Fact]
         public void ShouldHandleEmptyCollection_tuple()
         {
             var emptyList = new string[0];
-            var result = emptyList.Pairwise((i, i1) => (i,i1)).ToList(); //TODO: Add overload next API version
+            var result = emptyList.Pairwise().ToList();
             Assert.Empty(result);
         }
     }

--- a/Tests/PairwiseTests.cs
+++ b/Tests/PairwiseTests.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq;
+using Xunit;
+using WallyMathieu.Collections;
+using System;
+
+namespace Tests
+{
+    public class PairwiseTests
+    {
+        [Fact]
+        public void Pairwise()
+        {
+            var r = Enumerable.Range(0,5);
+            var result = r.Pairwise(Tuple.Create);
+            Assert.Equal(new[] { Tuple.Create(0, 1), Tuple.Create(1, 2), Tuple.Create(2, 3), Tuple.Create(3, 4) },
+                result.ToArray());
+        }
+        [Fact]
+        public void Pairwise_tuple()
+        {
+            var result = Enumerable.Range(0, 5).Pairwise((i, i1) => (i,i1)); //TODO: Add overload next API version
+            Assert.Equal(new[] { (0, 1), (1, 2), (2, 3), (3, 4) },
+                result.ToArray());
+        }
+
+        [Fact]
+        public void Pairwise_for_list_of_odd_length()
+        {
+            var result = Enumerable.Range(0, 4).Pairwise(Tuple.Create);
+            Assert.Equal(new[] { Tuple.Create(0, 1), Tuple.Create(1, 2), Tuple.Create(2, 3) },
+                result.ToArray());
+        }
+        [Fact]
+        public void Pairwise_for_list_of_odd_length_tuple()
+        {
+            var result = Enumerable.Range(0, 4).Pairwise((i, i1) => (i,i1)); //TODO: Add overload next API version
+            Assert.Equal(new[] { (0, 1), (1, 2), (2, 3) },
+                result.ToArray());
+        }
+        [Fact]
+        public void ShouldHandleEmptyCollection()
+        {
+            var emptyList = new string[0];
+            var result = emptyList.Pairwise(Tuple.Create).ToList();
+            Assert.Empty(result);
+        }
+        [Fact]
+        public void ShouldHandleEmptyCollection_tuple()
+        {
+            var emptyList = new string[0];
+            var result = emptyList.Pairwise((i, i1) => (i,i1)).ToList(); //TODO: Add overload next API version
+            Assert.Empty(result);
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,15 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="With" Version="5.0.2" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="With" Version="6.0.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/WallyMathieu.Collections/EnumerableExtensions.cs
+++ b/WallyMathieu.Collections/EnumerableExtensions.cs
@@ -96,16 +96,13 @@ namespace WallyMathieu.Collections
 
         /// <summary>
         /// Used to iterate over collection and get the collection elements pairwise.
-        /// Yields the result of the application of the map function over each pair.
         /// </summary>
         /// <remarks>
         /// Note that the same element will at most 2 times. For example for
-        /// 0.To(3).Pairwise(Tuple.Create).ToArray() you will get new[] { Tuple.Create(0, 1), Tuple.Create(1, 2), Tuple.Create(2, 3) }
+        /// 0.To(3).Pairwise().ToArray() you will get new[] { (0, 1), (1, 2), (2, 3) }
         /// </remarks>
         /// <param name="collection"></param>
-        /// <param name="func">The map of pairs</param>
         /// <typeparam name="T"></typeparam>
-        /// <typeparam name="TResult"></typeparam>
         /// <returns></returns>
         public static IEnumerable<(T,T)> Pairwise<T>(
             this IEnumerable<T> collection)

--- a/WallyMathieu.Collections/EnumerableExtensions.cs
+++ b/WallyMathieu.Collections/EnumerableExtensions.cs
@@ -94,5 +94,37 @@ namespace WallyMathieu.Collections
             yield return currentChunk;
         }
 
+        /// <summary>
+        /// Used to iterate over collection and get the collection elements pairwise.
+        /// Yields the result of the application of the map function over each pair.
+        /// </summary>
+        /// <remarks>
+        /// Note that the same element will at most 2 times. For example for
+        /// 0.To(3).Pairwise(Tuple.Create).ToArray() you will get new[] { Tuple.Create(0, 1), Tuple.Create(1, 2), Tuple.Create(2, 3) }
+        /// </remarks>
+        /// <param name="collection"></param>
+        /// <param name="func">The map of pairs</param>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <returns></returns>
+        public static IEnumerable<TResult> Pairwise<T, TResult>(
+            this IEnumerable<T> collection, Func<T, T, TResult> func)
+        {
+            using (var enumerator = collection.GetEnumerator())
+            {
+
+                if (!enumerator.MoveNext())
+                {
+                    yield break;
+                }
+
+                var last = enumerator.Current;
+                for (; enumerator.MoveNext();)
+                {
+                    yield return func(last, enumerator.Current);
+                    last = enumerator.Current;
+                }
+            }
+        }
     }
 }

--- a/WallyMathieu.Collections/EnumerableExtensions.cs
+++ b/WallyMathieu.Collections/EnumerableExtensions.cs
@@ -107,8 +107,8 @@ namespace WallyMathieu.Collections
         /// <typeparam name="T"></typeparam>
         /// <typeparam name="TResult"></typeparam>
         /// <returns></returns>
-        public static IEnumerable<TResult> Pairwise<T, TResult>(
-            this IEnumerable<T> collection, Func<T, T, TResult> func)
+        public static IEnumerable<(T,T)> Pairwise<T>(
+            this IEnumerable<T> collection)
         {
             using (var enumerator = collection.GetEnumerator())
             {
@@ -121,7 +121,7 @@ namespace WallyMathieu.Collections
                 var last = enumerator.Current;
                 for (; enumerator.MoveNext();)
                 {
-                    yield return func(last, enumerator.Current);
+                    yield return (last, enumerator.Current);
                     last = enumerator.Current;
                 }
             }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2022
 before_build:
   - ps: >-
       $buildId = $env:APPVEYOR_BUILD_NUMBER.PadLeft(5, '0');


### PR DESCRIPTION
Used to iterate over collection and get the collection elements pairwise.
Yields the result of the application of the map function over each pair.

```c#
using WallyMathieu.Collections;
...
var pairs = Enumerable.Range(0,4).Pairwise().ToArray(); 
// will be
Assert.Equal(new[] { (0, 1), (1, 2), (2, 3) },pairs);
```